### PR TITLE
Configure keys file path from environment variable

### DIFF
--- a/py/ns_extract_hashes.py
+++ b/py/ns_extract_hashes.py
@@ -25,6 +25,11 @@ args = parser.parse_args()
 
 INCP_PATH = args.input
 
+Pfs0.Keys.load_default()
+if not Pfs0.Keys.keys_loaded:
+    input("Press Enter to exit...")
+    sys.exit(1)
+
 def send_hook(message_content):
     try:
         print(message_content)

--- a/py/ns_extract_hashes.py
+++ b/py/ns_extract_hashes.py
@@ -49,7 +49,7 @@ def scan_file():
                     if isinstance(section, Pfs0.Pfs0):
                         Cnmt = section.getCnmt()
                         for entry in Cnmt.contentEntries:
-                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(byteorder = 'big')))
+                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(length=(min(entry.type.bit_length(), 1) + 7) // 8, byteorder = 'big')))
                             print(f'\n:{Cnmt.titleId} - Content.{entryType}')
                             print(f'> NCA ID: {entry.ncaId}')
                             print(f'> HASH: {entry.hash.hex()}')

--- a/py/ns_extract_meta.py
+++ b/py/ns_extract_meta.py
@@ -49,7 +49,7 @@ def scan_file():
                     if isinstance(section, Pfs0.Pfs0):
                         Cnmt = section.getCnmt()
                         
-                        titleType = FsTools.parse_cnmt_type_n(hx(Cnmt.titleType.to_bytes(byteorder = 'big')))
+                        titleType = FsTools.parse_cnmt_type_n(hx(Cnmt.titleType.to_bytes(length=(min(Cnmt.titleType.bit_length(), 1) + 7) // 8, byteorder = 'big')))
                         
                         print(f'\n:: CNMT: {Cnmt._path}\n')
                         print(f'Title ID: {Cnmt.titleId.upper()}')
@@ -57,8 +57,7 @@ def scan_file():
                         print(f'Title Type: {titleType}')
                         
                         for entry in Cnmt.contentEntries:
-                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(byteorder = 'big')))
-                            print(f'\n:{Cnmt.titleId} - Content.{entryType}')
+                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(length=(min(entry.type.bit_length(), 1) + 7) // 8, byteorder = 'big')))                            print(f'\n:{Cnmt.titleId} - Content.{entryType}')
                             print(f'> NCA ID: {entry.ncaId}')
                             print(f'> HASH: {entry.hash.hex()}')
                         

--- a/py/ns_extract_meta.py
+++ b/py/ns_extract_meta.py
@@ -25,6 +25,11 @@ args = parser.parse_args()
 
 INCP_PATH = args.input
 
+Pfs0.Keys.load_default()
+if not Pfs0.Keys.keys_loaded:
+    input("Press Enter to exit...")
+    sys.exit(1)
+
 def send_hook(message_content):
     try:
         print(message_content)
@@ -57,7 +62,8 @@ def scan_file():
                         print(f'Title Type: {titleType}')
                         
                         for entry in Cnmt.contentEntries:
-                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(length=(min(entry.type.bit_length(), 1) + 7) // 8, byteorder = 'big')))                            print(f'\n:{Cnmt.titleId} - Content.{entryType}')
+                            entryType = FsTools.get_metacontent_type(hx(entry.type.to_bytes(length=(min(entry.type.bit_length(), 1) + 7) // 8, byteorder = 'big')))
+                            print(f'\n:{Cnmt.titleId} - Content.{entryType}')
                             print(f'> NCA ID: {entry.ncaId}')
                             print(f'> HASH: {entry.hash.hex()}')
                         

--- a/py/ns_verify_folder.py
+++ b/py/ns_verify_folder.py
@@ -29,6 +29,11 @@ INCP_PATH = args.input
 WHOOK_URL = args.webhook_url
 SAVE_VLOG = bool(args.save_log)
 
+Verify.VerifyTools.Keys.load_default()
+if not Verify.VerifyTools.Keys.keys_loaded:
+    input("Press Enter to exit...")
+    sys.exit(1)
+
 def send_hook(message_content: str = '', PadPrint: bool = False):
     if message_content == '':
         return

--- a/py/nut/Keys.py
+++ b/py/nut/Keys.py
@@ -174,6 +174,7 @@ keyfiles = [
 	keyRootPath.joinpath("keys.txt"),
 	keyPyPath.joinpath("prod.keys"),
 	keyPyPath.joinpath("keys.txt"),
+	Path(os.environ.get("NSTOOLS_KEYS_FILE", "$NSTOOLS_KEYS_FILE")),
 ]
 
 loaded = False

--- a/py/nut/Keys.py
+++ b/py/nut/Keys.py
@@ -11,6 +11,7 @@ keys = {}
 titleKeks = []
 keyAreaKeys = []
 loadedKeysFile = "non-existing prod.keys/keys.txt"
+keys_loaded = False
 
 #This are NOT the keys but only a 4 bytes long checksum!
 #See https://en.wikipedia.org/wiki/Cyclic_redundancy_check
@@ -125,6 +126,7 @@ def load(fileName):
 		global keyAreaKeys
 		global titleKeks
 		global loadedKeysFile
+		global keys_loaded
 		loadedKeysFile = fileName
 		
 		with open(fileName, encoding="utf8") as f:
@@ -154,44 +156,46 @@ def load(fileName):
 			keyAreaKeys[i][1] = generateKek(key_area_key_ocean_source, masterKey, aes_kek_generation_source, aes_key_generation_source)
 			keyAreaKeys[i][2] = generateKek(key_area_key_system_source, masterKey, aes_kek_generation_source, aes_key_generation_source)
 		
-		return True
+		keys_loaded = True
+		return keys_loaded
 	except BaseException as e:
 		Print.error(format_exc())
 		Print.error(str(e))
 		
-		return False
+		keys_loaded = False
+		return keys_loaded
 
+def load_default():
+	keyPyPath = Path(sys.argv[0])
+	while not keyPyPath.is_dir():
+		keyPyPath = keyPyPath.parents[0]
+	keyRootPath = Path(os.path.abspath(os.path.join(str(keyPyPath), '..')))
 
-keyPyPath = Path(sys.argv[0])
-while not keyPyPath.is_dir():
-	keyPyPath = keyPyPath.parents[0]
-keyRootPath = Path(os.path.abspath(os.path.join(str(keyPyPath), '..')))
+	keyfiles = [
+		Path.home().joinpath(".switch", "prod.keys"),
+		Path.home().joinpath(".switch", "keys.txt"),
+		keyRootPath.joinpath("prod.keys"),
+		keyRootPath.joinpath("keys.txt"),
+		keyPyPath.joinpath("prod.keys"),
+		keyPyPath.joinpath("keys.txt"),
+		Path(os.environ.get("NSTOOLS_KEYS_FILE", "$NSTOOLS_KEYS_FILE")),
+	]
 
-keyfiles = [
-	Path.home().joinpath(".switch", "prod.keys"),
-	Path.home().joinpath(".switch", "keys.txt"),
-	keyRootPath.joinpath("prod.keys"),
-	keyRootPath.joinpath("keys.txt"),
-	keyPyPath.joinpath("prod.keys"),
-	keyPyPath.joinpath("keys.txt"),
-	Path(os.environ.get("NSTOOLS_KEYS_FILE", "$NSTOOLS_KEYS_FILE")),
-]
-
-loaded = False
-for kf in keyfiles:
-	if kf.is_file():
-		loaded = load(str(kf))
-		if loaded == True:
-			print(f'[:INFO:] Keys Loaded: {str(kf)}')
-			break
-
-if loaded == False:
-	errorMsg = ""
+	keys_loaded = False
 	for kf in keyfiles:
-		if errorMsg != "":
-			errorMsg += "\nor "
-		errorMsg += f"{str(kf)}"
-	errorMsg += " not found\n\nPlease dump your keys using https://github.com/shchmue/Lockpick_RCM/releases\n"
-	Print.error(errorMsg)
-	input("Press Enter to exit...")
-	sys.exit(1)
+		if kf.is_file():
+			keys_loaded = load(str(kf))
+			if keys_loaded == True:
+				print(f'[:INFO:] Keys Loaded: {str(kf)}')
+				break
+
+	if keys_loaded == False:
+		errorMsg = ""
+		for kf in keyfiles:
+			if errorMsg != "":
+				errorMsg += "\nor "
+			errorMsg += f"{str(kf)}"
+		errorMsg += " not found\n\nPlease dump your keys using https://github.com/shchmue/Lockpick_RCM/releases\n"
+		errorMsg = "Failed to load default keys files:\n" + errorMsg
+		Print.error(errorMsg)
+	return keys_loaded


### PR DESCRIPTION
This allows to externally configure NSTools to look for the keys file based on the environment variable `NSTOOLS_KEYS_FILE`, so the possible paths are not exclusively harcoded.

If the environment variable is not set, it will output `or $NSTOOLS_KEYS_FILE not found`, or its value if it is defined but not a file.

This also fix the `ns_extract` scripts, where the `length` argument is missing in the `to_bytes` calls. I don't know if the length can be hardcoded so the value is set according to [SO](https://stackoverflow.com/a/64502258).