### PR TITLE
Print: configure levels to print actually taken into account

### DIFF
--- a/py/nstools/nut/Print.py
+++ b/py/nstools/nut/Print.py
@@ -10,6 +10,9 @@ enableDebug = False
 silent = False
 	
 def info(s, pleaseNoPrint = None):
+	if silent or not enableInfo:
+		return
+	
 	if pleaseNoPrint == None:
 		sys.stdout.write(s + "\n")
 	else:
@@ -22,13 +25,21 @@ def info(s, pleaseNoPrint = None):
 		pleaseNoPrint.decrement()
 	
 def infoNoNewline(s):
+	if silent or not enableInfo:
+		return
 	sys.stdout.write(s)
 
 def error(s):
+	if silent or not enableError:
+		return
 	sys.stdout.write(s + "\n")
 
 def warning(s):
+	if silent or not enableWarning:
+		return
 	sys.stdout.write(s + "\n")
 
 def debug(s):
+	if silent or not enableWarning:
+		return
 	sys.stdout.write(s + "\n")


### PR DESCRIPTION
In the `Print` module you can configure wether or not to display logs depending on their severity, but these configuration variables are not taken into account. With this PR we can actually control what we want to display or just suppress the logs.