### PR TITLE
added meta_only argument to open() functions, to only open cmnt sections

### DIFF
--- a/py/nstools/Fs/BaseFs.py
+++ b/py/nstools/Fs/BaseFs.py
@@ -96,8 +96,8 @@ class BaseFs(File):
 		return (False if self.bktrSubsection is None else True) and self.bktrSubsection.isValid()
 		
 		
-	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		r = super(BaseFs, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		r = super(BaseFs, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 
 		if self.bktr1Buffer:
 			try:

--- a/py/nstools/Fs/Cnmt.py
+++ b/py/nstools/Fs/Cnmt.py
@@ -38,8 +38,8 @@ class Cnmt(File):
 		self.metaEntries = []
 
 
-	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		super(Cnmt, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only = False):
+		super(Cnmt, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		self.rewind()
 
 		self.titleId = hx(self.read(8)[::-1]).decode()

--- a/py/nstools/Fs/File.py
+++ b/py/nstools/Fs/File.py
@@ -51,7 +51,7 @@ class BaseFile:
 		self._bufferOffset = None
 		self._relativePos = 0x0
 			
-	def partition(self, offset = 0x0, size = None, n = None, cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, autoOpen = True):
+	def partition(self, offset = 0x0, size = None, n = None, cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, autoOpen = True, meta_only = False):
 		if not n:
 			n = File()
 		#Print.info('partition: ' + str(self) + ', ' + str(n))
@@ -69,7 +69,7 @@ class BaseFile:
 		
 		#Print.info('created partition for %s %x, size = %d' % (n.__class__.__name__, offset, size))
 		if autoOpen == True:
-			n.open(None, None, cryptoType, cryptoKey, cryptoCounter)
+			n.open(None, None, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		
 		return n
 
@@ -206,7 +206,7 @@ class BaseFile:
 			self.cryptoType = Type.Crypto.NONE
 
 
-	def open(self, path, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
+	def open(self, path, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
 		if path != None:
 			if self.isOpen():
 				self.close()

--- a/py/nstools/Fs/Hfs0.py
+++ b/py/nstools/Fs/Hfs0.py
@@ -111,8 +111,8 @@ class Hfs0(Pfs0):
 	def __init__(self, buffer, path = None, mode = None, cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
 		super(Hfs0, self).__init__(buffer, path, mode, cryptoType, cryptoKey, cryptoCounter)
 
-	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		r = super(BaseFs, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only = False):
+		r = super(BaseFs, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		self.rewind()
 
 		self.magic = self.read(0x4);
@@ -144,12 +144,15 @@ class Hfs0(Pfs0):
 
 			self.readInt32() # junk data
 
+			if meta_only and (name != 'secure' and not 'cnmt' in name):
+				continue
+
 			f = factory(Path(name))
 
 			f._path = name
 			f.offset = offset
 			f.size = size
-			self.files.append(self.partition(offset + headerSize, f.size, f))
+			self.files.append(self.partition(offset + headerSize, f.size, f, meta_only=meta_only))
 
 		self.files.reverse()
 

--- a/py/nstools/Fs/Nca.py
+++ b/py/nstools/Fs/Nca.py
@@ -67,8 +67,8 @@ class NcaHeader(File):
 		
 		super(NcaHeader, self).__init__(path, mode, cryptoType, cryptoKey, cryptoCounter)
 		
-	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		super(NcaHeader, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		super(NcaHeader, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		self.rewind()
 		self.signature1 = self.read(0x100)
 		self.signature2 = self.read(0x100)
@@ -214,8 +214,8 @@ class Nca(File):
 	def __getitem__(self, key):
 		return self.sectionFilesystems[key]
 
-	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		super(Nca, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		super(Nca, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		
 		self.header = NcaHeader()
 		self.partition(0x0, 0xC00, self.header, Type.Crypto.XTS, uhx(Keys.get('header_key')))

--- a/py/nstools/Fs/Nsp.py
+++ b/py/nstools/Fs/Nsp.py
@@ -199,8 +199,8 @@ class Nsp(Pfs0):
 	def getPath(self):
 		return self.path or ''
 			
-	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		super(Nsp, self).open(path or self.path, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		super(Nsp, self).open(path or self.path, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 					
 		return True
 

--- a/py/nstools/Fs/Pfs0.py
+++ b/py/nstools/Fs/Pfs0.py
@@ -228,8 +228,8 @@ class Pfs0(BaseFs):
 	def getFirstFileOffset(self):
 		return self.files[0].offset
 
-	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		r = super(Pfs0, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		r = super(Pfs0, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		self.rewind()
 		#self.setupCrypto()
 		#Print.info('cryptoType = ' + hex(self.cryptoType))
@@ -265,6 +265,9 @@ class Pfs0(BaseFs):
 
 			self.readInt32() # junk data
 
+			if meta_only and not 'cnmt' in name:
+				continue
+
 			f = factory(Path(name))
 
 			f._path = name
@@ -286,10 +289,10 @@ class Pfs0(BaseFs):
 		except:
 			pass
 
-		for i in range(fileCount):
-			if self.files[i] != ticket:
+		for file in self.files:
+			if file != ticket:
 				try:
-					self.files[i].open(None, None)
+					file.open(None, None)
 				except:
 					pass
 

--- a/py/nstools/Fs/Ticket.py
+++ b/py/nstools/Fs/Ticket.py
@@ -31,8 +31,8 @@ class Ticket(File):
 		self.signatureSizes[Type.TicketSignature.RSA_2048_SHA256] = 0x100
 		self.signatureSizes[Type.TicketSignature.ECDSA_SHA256] = 0x3C
 
-	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		super(Ticket, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, file = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only = False):
+		super(Ticket, self).open(file, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		self.rewind()
 		self.signatureType = self.readInt32()
 		try:

--- a/py/nstools/Fs/Xci.py
+++ b/py/nstools/Fs/Xci.py
@@ -308,8 +308,8 @@ class Xci(File):
 		self.gamecardCert = GamecardCertificate(self.partition(0x7000, 0x200))
 		
 
-	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1):
-		r = super(Xci, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter)
+	def open(self, path = None, mode = 'rb', cryptoType = -1, cryptoKey = -1, cryptoCounter = -1, meta_only=False):
+		r = super(Xci, self).open(path, mode, cryptoType, cryptoKey, cryptoCounter, meta_only)
 		if self.isFullXci():
 			self.readKeyArea()
 			self.headerOffset = 0x1000
@@ -317,7 +317,7 @@ class Xci(File):
 		self.readHeader()
 		self.seek(self.hfs0Offset + self.headerOffset)
 		self.hfs0 = Hfs0(None, cryptoKey = None)
-		self.partition(self.hfs0Offset + self.headerOffset, None, self.hfs0, cryptoKey = None)
+		self.partition(self.hfs0Offset + self.headerOffset, None, self.hfs0, cryptoKey = None, meta_only = meta_only)
 
 	def unpack(self, path, extractregex="*"):
 		os.makedirs(str(path), exist_ok=True)


### PR DESCRIPTION
This adds the `meta_only` boolean argument to all `open()` functions. If set to `True` then only the `cnmt` entries will be opened instead of the whole file, to speed up the process if all we want to do is identify contents.

From my testing the identification is 2 to 10 times faster depending on the file size.